### PR TITLE
Fix a build error on Mac OSX 10.8.3, 64-bit, GHC 7.4

### DIFF
--- a/Data/Packer.hs
+++ b/Data/Packer.hs
@@ -286,7 +286,7 @@ putBytes :: ByteString -> Packing ()
 putBytes bs =
     packCheckAct len $ \ptr ->
     withForeignPtr fptr $ \ptr2 ->
-    B.memcpy ptr (ptr2 `plusPtr` o) len
+    B.memcpy ptr (ptr2 `plusPtr` o) (fromIntegral len)
   where (fptr,o,len) = B.toForeignPtr bs
 
 -- | Put an arbitrary type with the Storable class constraint.


### PR DESCRIPTION
Tue Sep 03 07:24:52:~/Code/haskell/psort$ sudo cabal install packer
Resolving dependencies...
Downloading packer-0.1.1...
Configuring packer-0.1.1...
Building packer-0.1.1...
Preprocessing library packer-0.1.1...
[1 of 5] Compiling Data.Packer.Endian ( Data/Packer/Endian.hs, dist/build/Data/Packer/Endian.o )
[2 of 5] Compiling Data.Packer.Internal ( Data/Packer/Internal.hs, dist/build/Data/Packer/Internal.o )
[3 of 5] Compiling Data.Packer.Unsafe ( Data/Packer/Unsafe.hs, dist/build/Data/Packer/Unsafe.o )
[4 of 5] Compiling Data.Packer.IO   ( Data/Packer/IO.hs, dist/build/Data/Packer/IO.o )
[5 of 5] Compiling Data.Packer      ( Data/Packer.hs, dist/build/Data/Packer.o )

Data/Packer.hs:288:37:
    Couldn't match expected type `Foreign.C.Types.CSize'
                with actual type`Int'
    In the third argument of `B.memcpy', namely`len'
    In the expression: B.memcpy ptr (ptr2 `plusPtr` o) len
    In the second argument of `($)', namely
`\ ptr2 -> B.memcpy ptr (ptr2 `plusPtr` o) len'
cabal: Error: some packages failed to install:
packer-0.1.1 failed during the building phase. The exception was:
ExitFailure 1

No promises that this actually fixed it though I did run the tests 

Tue Sep 03 08:00:00:~/Code/hs-packer/Tests (master)$ runhaskell Tests.hs 
serialization:
  basic cases:
    packing 4 bytes: [OK]
    packing out of bounds: [OK]
    unpacking out of bounds: [OK]
    unpacking set pos before: [OK]
    unpacking set pos after: [OK]
  endianness cases:
    put16LE: [OK]
    get16LE: [OK]
    put16BE: [OK]
    get16BE: [OK]
    put32LE: [OK]
    get32LE: [OK]
    put32BE: [OK]
    get32BE: [OK]
    put64LE: [OK]
    get64LE: [OK]
    put64BE: [OK]
    get64BE: [OK]
  unpacking.packing=id: [OK, passed 100 tests]

```
     Properties  Test Cases   Total       
```

 Passed  1           17           18  
 Failed  0           0            0  
 Total   1           17           18          
