### PR TITLE
Add IEEE754 float coersion

### DIFF
--- a/Data/Packer.hs
+++ b/Data/Packer.hs
@@ -45,6 +45,10 @@ module Data.Packer
     , getRemaining
     , getRemainingCopy
     , getStorable
+    , getFloat32LE
+    , getFloat32BE
+    , getFloat64LE
+    , getFloat64BE
     , isolate
     -- * Packing functions
     , packGetPosition
@@ -66,6 +70,10 @@ module Data.Packer
     , putHoleWord64BE
     , putBytes
     , putStorable
+    , putFloat32LE
+    , putFloat32BE
+    , putFloat64LE
+    , putFloat64BE
     , fillHole
     ) where
 
@@ -74,6 +82,7 @@ import Data.Packer.Internal
 import Data.Packer.Unsafe
 import Data.Packer.IO
 import Data.Packer.Endian
+import Data.Packer.IEEE754
 import Foreign.Ptr
 import Foreign.ForeignPtr
 import Data.ByteString (ByteString)
@@ -157,6 +166,22 @@ getWord64LE = unpackCheckAct 8 (peekAnd le64Host . castPtr)
 getWord64BE :: Unpacking Word64
 getWord64BE = unpackCheckAct 8 (peekAnd be64Host . castPtr)
 {-# INLINE getWord64BE #-}
+
+-- | Read a Float in little endian IEEE-754 format
+getFloat32LE :: Unpacking Float
+getFloat32LE = wordToFloat <$> getWord32LE
+
+-- | Read a Float in big endian IEEE-754 format
+getFloat32BE :: Unpacking Float
+getFloat32BE = wordToFloat <$> getWord32BE
+
+-- | Read a Double in little endian IEEE-754 format
+getFloat64LE :: Unpacking Double
+getFloat64LE = wordToDouble <$> getWord64LE
+
+-- | Read a Double in big endian IEEE-754 format
+getFloat64BE :: Unpacking Double
+getFloat64BE = wordToDouble <$> getWord64BE
 
 -- | Get a number of bytes in bytestring format.
 --
@@ -296,6 +321,21 @@ putHoleWord64BE = putHoleWord64_ be64Host
 -- | Put a Word64 Hole in little endian
 putHoleWord64LE = putHoleWord64_ le64Host
 
+-- | Write a Float in little endian IEEE-754 format
+putFloat32LE :: Float -> Packing ()
+putFloat32LE = putWord32LE . floatToWord
+
+-- | Write a Float in big endian IEEE-754 format
+putFloat32BE :: Float -> Packing ()
+putFloat32BE = putWord32BE . floatToWord
+
+-- | Write a Double in little endian IEEE-754 format
+putFloat64LE :: Double -> Packing ()
+putFloat64LE = putWord64LE . doubleToWord
+
+-- | Write a Double in big endian IEEE-754 format
+putFloat64BE :: Double -> Packing ()
+putFloat64BE = putWord64BE . doubleToWord
 
 -- | Put a Bytestring.
 putBytes :: ByteString -> Packing ()

--- a/Data/Packer/IEEE754.hs
+++ b/Data/Packer/IEEE754.hs
@@ -1,0 +1,54 @@
+-- |
+-- Module      : Data.Packer.IEEE754
+-- License     : BSD-style
+-- Maintainer  : Vincent Hanquez <vincent@snarc.org>
+-- Stability   : experimental
+-- Portability : unknown
+--
+-- IEEE-754 parsing, lifted from the cereal package by Christian Marie <pingu@ponies.io>
+--
+-- Implementation is described here:
+-- <http://stackoverflow.com/questions/6976684/converting-ieee-754-floating-point-in-haskell-word32-64-to-and-from-haskell-float/7002812#7002812>
+--
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+module Data.Packer.IEEE754 (
+      wordToDouble
+    , wordToFloat
+    , doubleToWord
+    , floatToWord
+) where
+
+import Control.Monad.ST (runST, ST)
+
+import Data.Array.ST (newArray, readArray, MArray, STUArray)
+import Data.Word (Word32, Word64)
+
+#if __GLASGOW_HASKELL__ >= 704
+import Data.Array.Unsafe (castSTUArray)
+#else
+import Data.Array.ST (castSTUArray)
+#endif
+
+{-# INLINE wordToFloat #-}
+wordToFloat :: Word32 -> Float
+wordToFloat x = runST (cast x)
+
+{-# INLINE floatToWord #-}
+floatToWord :: Float -> Word32
+floatToWord x = runST (cast x)
+
+{-# INLINE wordToDouble #-}
+wordToDouble :: Word64 -> Double
+wordToDouble x = runST (cast x)
+
+{-# INLINE doubleToWord #-}
+doubleToWord :: Double -> Word64
+doubleToWord x = runST (cast x)
+
+{-# INLINE cast #-}
+cast :: (MArray (STUArray s) a (ST s),
+         MArray (STUArray s) b (ST s)) =>
+        a -> ST s b
+cast x = newArray (0 :: Int, 0) x >>= castSTUArray >>= flip readArray 0

--- a/Tests/Tests.hs
+++ b/Tests/Tests.hs
@@ -33,17 +33,21 @@ toEndianCase (n, pAct, gAct, bs, v) =
     , testCase ("get" ++ n) (runUnpacking gAct bs @=? v)
     ]
 
-data DataAtom = W8    Word8
-              | W16   Word16
-              | W16BE Word16
-              | W16LE Word16
-              | W32   Word32
-              | W32BE Word32
-              | W32LE Word32
-              | W64   Word64
-              | W64BE Word64
-              | W64LE Word64
-              | Bytes B.ByteString
+data DataAtom = W8        Word8
+              | W16       Word16
+              | W16BE     Word16
+              | W16LE     Word16
+              | W32       Word32
+              | W32BE     Word32
+              | W32LE     Word32
+              | W64       Word64
+              | W64BE     Word64
+              | W64LE     Word64
+              | Float32LE Float
+              | Float32BE Float
+              | Float64LE Double
+              | Float64BE Double
+              | Bytes     B.ByteString
               deriving (Show,Eq)
 
 newtype DataStream = DataStream [DataAtom]
@@ -56,17 +60,21 @@ arbitraryBS =
 
 instance Arbitrary DataAtom where
     arbitrary = oneof
-        [ W8    <$> arbitrary
-        , W16   <$> arbitrary
-        , W16BE <$> arbitrary
-        , W16LE <$> arbitrary
-        , W32   <$> arbitrary
-        , W32BE <$> arbitrary
-        , W32LE <$> arbitrary
-        , W64   <$> arbitrary
-        , W64BE <$> arbitrary
-        , W64LE <$> arbitrary
-        , Bytes <$> arbitraryBS
+        [ W8        <$> arbitrary
+        , W16       <$> arbitrary
+        , W16BE     <$> arbitrary
+        , W16LE     <$> arbitrary
+        , W32       <$> arbitrary
+        , W32BE     <$> arbitrary
+        , W32LE     <$> arbitrary
+        , W64       <$> arbitrary
+        , W64BE     <$> arbitrary
+        , W64LE     <$> arbitrary
+        , Float32LE <$> arbitrary
+        , Float32LE <$> arbitrary
+        , Float64BE <$> arbitrary
+        , Float64BE <$> arbitrary
+        , Bytes     <$> arbitraryBS
         ]
 
 instance Arbitrary DataStream where
@@ -76,44 +84,56 @@ instance Arbitrary DataStream where
 
 packDataStream (DataStream atoms) = runPacking (foldl sumLen 0 atoms) (mapM_ process atoms)
     where process :: DataAtom -> Packing ()
-          process (W8 w)    = putWord8 w
-          process (W16 w)   = putWord16 w
-          process (W32 w)   = putWord32 w
-          process (W64 w)   = putWord64 w
-          process (W16LE w) = putWord16LE w
-          process (W32LE w) = putWord32LE w
-          process (W64LE w) = putWord64LE w
-          process (W16BE w) = putWord16BE w
-          process (W32BE w) = putWord32BE w
-          process (W64BE w) = putWord64BE w
-          process (Bytes b) = putBytes b
+          process (W8 w)        = putWord8 w
+          process (W16 w)       = putWord16 w
+          process (W32 w)       = putWord32 w
+          process (W64 w)       = putWord64 w
+          process (W16LE w)     = putWord16LE w
+          process (W32LE w)     = putWord32LE w
+          process (W64LE w)     = putWord64LE w
+          process (W16BE w)     = putWord16BE w
+          process (W32BE w)     = putWord32BE w
+          process (W64BE w)     = putWord64BE w
+          process (Bytes b)     = putBytes b
+          process (Float32LE w) = putFloat32LE w
+          process (Float32BE w) = putFloat32BE w
+          process (Float64LE w) = putFloat64LE w
+          process (Float64BE w) = putFloat64BE w
 
-          sumLen a (W8 _)    = a + 1
-          sumLen a (W16 _)   = a + 2
-          sumLen a (W16LE _) = a + 2
-          sumLen a (W16BE _) = a + 2
-          sumLen a (W32 _)   = a + 4
-          sumLen a (W32LE _) = a + 4
-          sumLen a (W32BE _) = a + 4
-          sumLen a (W64 _)   = a + 8
-          sumLen a (W64LE _) = a + 8
-          sumLen a (W64BE _) = a + 8
-          sumLen a (Bytes b) = a + B.length b
+          sumLen a (W8 _)        = a + 1
+          sumLen a (W16 _)       = a + 2
+          sumLen a (W16LE _)     = a + 2
+          sumLen a (W16BE _)     = a + 2
+          sumLen a (W32 _)       = a + 4
+          sumLen a (W32LE _)     = a + 4
+          sumLen a (W32BE _)     = a + 4
+          sumLen a (Float32LE _) = a + 4
+          sumLen a (Float32BE _) = a + 4
+          sumLen a (Float64LE _) = a + 8
+          sumLen a (Float64BE _) = a + 8
+          sumLen a (W64 _)       = a + 8
+          sumLen a (W64LE _)     = a + 8
+          sumLen a (W64BE _)     = a + 8
+          sumLen a (Bytes b)     = a + B.length b
 
 unpackDataStream :: DataStream -> B.ByteString -> DataStream
 unpackDataStream (DataStream atoms) bs = DataStream $ runUnpacking (mapM process atoms) bs
     where process :: DataAtom -> Unpacking DataAtom
-          process (W8 _)    = W8 <$> getWord8
-          process (W16 _)   = W16 <$> getWord16
-          process (W32 _)   = W32 <$> getWord32
-          process (W64 _)   = W64 <$> getWord64
-          process (W16LE _) = W16LE <$> getWord16LE
-          process (W32LE _) = W32LE <$> getWord32LE
-          process (W64LE _) = W64LE <$> getWord64LE
-          process (W16BE _) = W16BE <$> getWord16BE
-          process (W32BE _) = W32BE <$> getWord32BE
-          process (W64BE _) = W64BE <$> getWord64BE
-          process (Bytes b) = Bytes <$> getBytes (B.length b)
+          process (W8 _)        = W8        <$> getWord8
+          process (W16 _)       = W16       <$> getWord16
+          process (W32 _)       = W32       <$> getWord32
+          process (W64 _)       = W64       <$> getWord64
+          process (W16LE _)     = W16LE     <$> getWord16LE
+          process (W32LE _)     = W32LE     <$> getWord32LE
+          process (W64LE _)     = W64LE     <$> getWord64LE
+          process (W16BE _)     = W16BE     <$> getWord16BE
+          process (W32BE _)     = W32BE     <$> getWord32BE
+          process (W64BE _)     = W64BE     <$> getWord64BE
+          process (Float32LE _) = Float32LE <$> getFloat32LE
+          process (Float32BE _) = Float32BE <$> getFloat32BE
+          process (Float64LE _) = Float64LE <$> getFloat64LE
+          process (Float64BE _) = Float64BE <$> getFloat64BE
+          process (Bytes b)     = Bytes     <$> getBytes (B.length b)
 
 assertException msg filterE act =
     handleJust filterE (\_ -> return ()) (evaluate act >> assertFailure (msg ++ " didn't raise the proper exception"))

--- a/packer.cabal
+++ b/packer.cabal
@@ -16,6 +16,7 @@ Homepage:            http://github.com/vincenthz/hs-packer
 Library
   Build-Depends:     base >= 3 && < 5
                    , bytestring
+                   , array
                    , mtl
   Exposed-modules:   Data.Packer
                      Data.Packer.Unsafe


### PR DESCRIPTION
Hi, I'm trying to speed up the haskell protobuf library by replacing it's use of cereal with your implementation. Unfortunately it isn't quite as featureful yet.

Can we add IEEE754 floats?

I'll also need an Alternative instance for Unpacking, I'm wondering if you would like to implement that or shall I?
