### PR TITLE
Allow runUnpacking (unpackSetPosition 0) ByteString.empty

### DIFF
--- a/Data/Packer/Internal.hs
+++ b/Data/Packer/Internal.hs
@@ -197,7 +197,7 @@ unpackCheckAct n act = unpackCheckActRef n (\_ -> act)
 -- This is useful to skip bytes or when using absolute offsets from a header or some such.
 unpackSetPosition :: Int -> Unpacking ()
 unpackSetPosition pos = Unpacking $ \(fptr, iniBlock@(Memory iniPtr sz)) _ -> do
-    when (pos < 0 || pos >= sz) (throwIO $ OutOfBoundUnpacking pos 0)
+    when (pos < 0 || pos > sz) (throwIO $ OutOfBoundUnpacking pos 0)
     return ((), Memory (iniPtr `plusPtr` pos) (sz-pos))
 
 -- | Get the position in the memory block.

--- a/Tests/Tests.hs
+++ b/Tests/Tests.hs
@@ -151,6 +151,7 @@ main = defaultMain
                                                     (runUnpacking (unpackSetPosition 2) (B.singleton 1)))
             , testCase "unpacking set pos after" (assertException "unpacking position" (\(OutOfBoundUnpacking _ _) -> Just ())
                                                     (runUnpacking (unpackSetPosition (-1)) (B.singleton 1)))
+            , testCase "unpacking set pos end" (runUnpacking (unpackSetPosition 0) (B.empty) @=? ())
             , testCase "unpacking isolate" (runUnpacking (isolate 2 (getBytes 2) >>= \i -> getWord8 >>= \r -> return (i,r)) (B.pack [1,2,3]) @=? (B.pack [1,2], 3))
             , testCase "unpacking isolate out of bounds" $
                 assertException "unpacking isolate" (\(OutOfBoundUnpacking _ _) -> Just ())


### PR DESCRIPTION
I would not personally consider this a backwards incompatible change as I consider the old behaviour buggy. Perhaps this is, though.

Closes #7.
